### PR TITLE
Adds more Poster processes and (optional) healthappd

### DIFF
--- a/yeetd/main.swift
+++ b/yeetd/main.swift
@@ -22,7 +22,9 @@ enum ProcessConfig {
         "PhotosPosterProvider",
         "AvatarPosterExtension",
         "GradientPosterExtension",
-        "MonogramPosterExtension"
+        "MonogramPosterExtension",
+        "UnityPosterExtension",
+        "PridePosterExtension",
     ]
 
     static var processes: Set<String> {
@@ -33,6 +35,9 @@ enum ProcessConfig {
         var processes = defaultProcesses
         if userDefaults.bool(forKey: "killapsd") {
             processes.insert("apsd")
+        }
+        if userDefaults.bool(forKey: "killhealthappd") {
+            processes.insert("healthappd")
         }
         return processes
     }


### PR DESCRIPTION
This adds the `UnityPosterExtension` and `PridePosterExtension` processes, which I've noticed were using a lot of CPU on my machine without any benefit.

Following the same pattern as the one for `apsd`, I've also included `healthappd`, which is often using a lot of CPU. This will definitely impact people developing apps against HealthKit, but for most use cases it's also safe to disable.